### PR TITLE
fix: Login To CMS rearranged in mobile menu

### DIFF
--- a/theme/site/collections/menu.overrides
+++ b/theme/site/collections/menu.overrides
@@ -80,6 +80,9 @@
 }
 
 @media only screen and (max-width: @mobileWidth) {
+   .navigation-search-wrapper{
+    display: inline-block;
+  }
   .header-wrapper .ui.pointing.secondary.stackable.open.menu {
     position: fixed;
     z-index: 100;
@@ -212,6 +215,12 @@
     span {
       display: none;
     }
+  }
+  .ui.secondary.pointing.menu .item{
+    align-self:unset;
+  }
+  .ui.secondary.menu .item {
+    align-self: unset;
   }
 }
 


### PR DESCRIPTION
I fixed the bug which didn't display Login to CMS text in the navbar correctly when the browser is in mobile view.